### PR TITLE
Add Tesseract engine and shared palette

### DIFF
--- a/data/palettes/visionary.json
+++ b/data/palettes/visionary.json
@@ -1,0 +1,20 @@
+{
+  "visionary": {
+    "core": {
+      "indigo": "#280050",
+      "violet": "#460082",
+      "blue": "#0080FF",
+      "green": "#00FF80",
+      "amber": "#FFC800",
+      "light": "#FFFFFF"
+    },
+    "secondary": {
+      "crimson": "#B7410E",
+      "gold": "#FFD700",
+      "slate": "#2E2E2E",
+      "silver": "#C0C0C0",
+      "sky": "#87CEFA",
+      "shadow": "#4B0082"
+    }
+  }
+}

--- a/engines/Tesseract.js
+++ b/engines/Tesseract.js
@@ -1,0 +1,101 @@
+// ✦ Codex 144:99 — preserve original intention
+import * as THREE from 'three';
+
+export default class TesseractEngine {
+  constructor({ animate = false } = {}) {
+    this.animate = animate;
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(60, 1, 0.1, 1000);
+    this.camera.position.set(3, 3, 5);
+    this.renderer = null;
+    this.nodes = [];
+    this.nodeMeshes = new Map();
+    this.highlightColor = null;
+    this.selectCallback = null;
+    this.palette = null;
+    this.raycaster = new THREE.Raycaster();
+    this.pointer = new THREE.Vector2();
+  }
+
+  async loadPalette(url = 'data/palettes/visionary.json', use = 'visionary.core') {
+    const res = await fetch(url);
+    const json = await res.json();
+    const path = use.split('.');
+    this.palette = path.reduce((acc, key) => (acc ? acc[key] : undefined), json);
+    this.highlightColor = this.palette ? this.palette.blue : '#ffffff';
+  }
+
+  mount(container) {
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setSize(container.clientWidth, container.clientHeight);
+    container.appendChild(this.renderer.domElement);
+    this.camera.aspect = container.clientWidth / container.clientHeight;
+    this.camera.updateProjectionMatrix();
+    container.addEventListener('pointerdown', e => this.onPointerDown(e));
+    if (this.animate) this.startLoop();
+    else this.render();
+  }
+
+  setNodes(nodeList = []) {
+    this.nodes = nodeList;
+    const group = new THREE.Group();
+    const color = this.palette ? this.palette.indigo : '#888888';
+    nodeList.forEach(node => {
+      const geom = new THREE.SphereGeometry(0.05, 16, 16);
+      const mat = new THREE.MeshBasicMaterial({ color });
+      const mesh = new THREE.Mesh(geom, mat);
+      mesh.position.set(node.x, node.y, node.z);
+      mesh.userData.id = node.id;
+      group.add(mesh);
+      this.nodeMeshes.set(node.id, mesh);
+    });
+    this.scene.add(group);
+    this.render();
+  }
+
+  transform(matrix) {
+    if (matrix instanceof THREE.Matrix4) {
+      this.scene.applyMatrix4(matrix);
+      this.render();
+    }
+  }
+
+  highlight(nodeId) {
+    const mesh = this.nodeMeshes.get(nodeId);
+    if (mesh && this.highlightColor) {
+      mesh.material.color.set(this.highlightColor);
+      this.render();
+    }
+  }
+
+  onSelect(callback) {
+    this.selectCallback = callback;
+  }
+
+  onPointerDown(event) {
+    if (!this.renderer) return;
+    const rect = this.renderer.domElement.getBoundingClientRect();
+    this.pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+    this.pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+    this.raycaster.setFromCamera(this.pointer, this.camera);
+    const intersects = this.raycaster.intersectObjects(Array.from(this.nodeMeshes.values()));
+    if (intersects.length > 0) {
+      const id = intersects[0].object.userData.id;
+      if (this.selectCallback) this.selectCallback(id);
+    }
+  }
+
+  startLoop() {
+    const loop = () => {
+      requestAnimationFrame(loop);
+      this.renderer.render(this.scene, this.camera);
+    };
+    loop();
+  }
+
+  render() {
+    if (this.renderer) {
+      this.renderer.render(this.scene, this.camera);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add shared visionary palette for engines
- implement TesseractEngine with mount, setNodes, transform, highlight, and onSelect APIs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9237a0cc4832880698fd9f54896ca