### PR TITLE
Add ritual UI modules and cosmogenesis scaffolding

### DIFF
--- a/assets/data/tarot_absyssia.json
+++ b/assets/data/tarot_absyssia.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": 0,
+    "name": "The Fool",
+    "arcana": "major",
+    "realm": "absyssia",
+    "stylepack": "standard",
+    "toneHz": 432,
+    "angelId": "Raziel",
+    "daemonId": "Bael"
+  },
+  {
+    "id": 1,
+    "name": "The Magician",
+    "arcana": "major",
+    "realm": "absyssia",
+    "stylepack": "standard",
+    "toneHz": 480
+  }
+]

--- a/assets/js/effects/planetary-light.js
+++ b/assets/js/effects/planetary-light.js
@@ -1,0 +1,7 @@
+// Planetary light effect -- applies overlay blend mode to vitrail overlays
+export function applyPlanetaryLight(root = document) {
+  const nodes = root.querySelectorAll('.overlay-vitrail');
+  nodes.forEach(el => {
+    el.style.mixBlendMode = 'overlay';
+  });
+}

--- a/assets/js/engines/fractal-engine.js
+++ b/assets/js/engines/fractal-engine.js
@@ -1,0 +1,23 @@
+// Simple fractal rendering engine
+export function drawFractal(canvas) {
+  const ctx = canvas.getContext('2d');
+  const width = canvas.width;
+  const height = canvas.height;
+  for (let x = 0; x < width; x++) {
+    for (let y = 0; y < height; y++) {
+      let zx = 0, zy = 0;
+      const cx = (x - width / 2) * 4 / width;
+      const cy = (y - height / 2) * 4 / width;
+      let iter = 0;
+      while (zx*zx + zy*zy < 4 && iter < 64) {
+        const xt = zx*zx - zy*zy + cx;
+        zy = 2*zx*zy + cy;
+        zx = xt;
+        iter++;
+      }
+      const c = iter === 64 ? 0 : 255 - iter * 4;
+      ctx.fillStyle = `rgb(${c}, ${c}, ${c})`;
+      ctx.fillRect(x, y, 1, 1);
+    }
+  }
+}

--- a/assets/js/ui/ritual.js
+++ b/assets/js/ui/ritual.js
@@ -1,0 +1,19 @@
+// UI helpers for ritual interactions
+
+// Initialize a ritual listener on a given element
+export function initRitual(element, handler) {
+  const el = typeof element === 'string' ? document.querySelector(element) : element;
+  if (!el) return;
+  el.addEventListener('click', (ev) => {
+    const name = ev.target.getAttribute('data-ritual');
+    if (name && typeof handler === 'function') {
+      handler(name, ev);
+    }
+  });
+}
+
+// Dispatch a ritual start event
+export function startRitual(name, detail = {}) {
+  const evt = new CustomEvent('ritual:start', { detail: { name, ...detail } });
+  document.dispatchEvent(evt);
+}

--- a/assets/js/ui/room-plaque.js
+++ b/assets/js/ui/room-plaque.js
@@ -1,0 +1,19 @@
+// Room plaque component for displaying contextual info
+export class RoomPlaque {
+  constructor(element) {
+    this.el = typeof element === 'string' ? document.querySelector(element) : element;
+  }
+  show(text) {
+    if (!this.el) return;
+    this.el.textContent = text;
+    this.el.style.display = 'block';
+  }
+  hide() {
+    if (!this.el) return;
+    this.el.style.display = 'none';
+  }
+}
+
+export function attachRoomPlaque(selector) {
+  return new RoomPlaque(selector);
+}

--- a/business_promo.md
+++ b/business_promo.md
@@ -6,7 +6,7 @@ tags: [Visionary Art, Reiki, Trauma Healing, Psycho Magic, Neurodivergence, Alch
 
 # Rebecca Respawn -- Creative Founder & Visionary Healer
 
-![LuxCrux Logo](../assets/images/luxcrux_logo.png)
+![LuxCrux Logo](/assets/images/luxcrux_logo.png)
 
 I’m Rebecca Respawn -- artist, architect-scribe, and visionary entrepreneur -- emerging from years of trauma and isolation to create a sacred space where healing, magic, and creativity fuse into powerful alchemical expression.
 

--- a/cathedral.html
+++ b/cathedral.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Cathedral</title>
+  <link rel="stylesheet" href="/assets/covers/css/perm-style.css" />
+</head>
+<body>
+  <div class="grid center">
+    <a href="/chapels/cosmogenesis/index.html">Cosmogenesis</a>
+  </div>
+</body>
+</html>

--- a/chapels/cosmogenesis/index.html
+++ b/chapels/cosmogenesis/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Cosmogenesis Chapel</title>
+  <script type="module">
+    import { drawFractal } from '/assets/js/engines/fractal-engine.js';
+    document.addEventListener('DOMContentLoaded', () => {
+      const canvas = document.getElementById('fractal');
+      drawFractal(canvas);
+    });
+  </script>
+</head>
+<body>
+  <canvas id="fractal" width="400" height="400"></canvas>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add reusable ritual and room plaque UI modules
- Introduce planetary light effect and fractal engine
- Scaffold Cosmogenesis chapel, cathedral link, and tarot data schema
- Standardize asset paths to root-relative

## Testing
- `node --input-type=module -e "Promise.all([import('./assets/js/ui/ritual.js'),import('./assets/js/ui/room-plaque.js'),import('./assets/js/effects/planetary-light.js'),import('./assets/js/engines/fractal-engine.js')]).then(()=>console.log('modules ok'))"`
- `node -e "const fs=require('fs');console.log(JSON.parse(fs.readFileSync('assets/data/tarot_absyssia.json','utf8')).length)"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9271c0fb48328ba17d524b83c0245