### PR TITLE
feat: add visionary art generator

### DIFF
--- a/liber_arcanae/README.md
+++ b/liber_arcanae/README.md
@@ -1,0 +1,5 @@
+# Liber Arcanae: Living Tarot System
+
+This module initiates the connection between Codex 144:99 and the Living Tarot System. It houses experimental scripts and artifacts for visionary explorations.
+
+- `visionary_dream.py` – generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey.

--- a/liber_arcanae/visionary_dream.py
+++ b/liber_arcanae/visionary_dream.py
@@ -1,0 +1,37 @@
+# Visionary Dream: Living Tarot Art
+# Generates a museum-quality piece of visionary art inspired by Alex Grey.
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
+
+# Canvas configuration
+width, height = 1920, 1080
+dpi = 100
+fig = plt.figure(figsize=(width / dpi, height / dpi), dpi=dpi)
+ax = fig.add_axes([0, 0, 1, 1])
+ax.axis('off')
+
+# Coordinate grid
+gx = np.linspace(-3, 3, width)
+gy = np.linspace(-3, 3, height)
+X, Y = np.meshgrid(gx, gy)
+
+# Base pattern
+Z = np.sin(X**2 + Y**2) + np.cos(3 * X) * np.sin(3 * Y)
+
+# Custom palette inspired by Alex Grey's vivid spectrum
+colors = ['#000000', '#0d0887', '#6a00a8', '#b12a90', '#fdca26']
+cmap = LinearSegmentedColormap.from_list('alex_grey', colors)
+
+# Render base layer
+ax.imshow(Z, cmap=cmap, interpolation='bilinear')
+
+# Overlay radial symmetry
+theta = np.arctan2(Y, X)
+radial = np.sin(10 * theta)
+ax.imshow(radial, cmap='twilight', alpha=0.4, interpolation='bilinear')
+
+# Save result
+plt.savefig('Visionary_Dream.png', dpi=dpi, bbox_inches='tight', pad_inches=0)
+plt.close()


### PR DESCRIPTION
## Summary
- introduce Liber Arcanae module linking Codex 144:99 with the Living Tarot System
- add `visionary_dream.py` to generate Alex Grey-inspired art as `Visionary_Dream.png`

## Testing
- `pip install numpy matplotlib` *(fails: Cannot connect to proxy)*
- `python liber_arcanae/visionary_dream.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b9cc39a67c8328b0c8d25753d0d2cc