### PR TITLE
feat: add visionary art generator

### DIFF
--- a/liber_arcanae/README.md
+++ b/liber_arcanae/README.md
@@ -1,0 +1,5 @@
+# Liber Arcanae: Living Tarot System
+
+This module initiates the connection between Codex 144:99 and the Living Tarot System. It houses experimental scripts and artifacts for visionary explorations.
+
+- `visionary_dream.py` – generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey and only the Python standard library.

--- a/liber_arcanae/visionary_dream.py
+++ b/liber_arcanae/visionary_dream.py
@@ -1,0 +1,48 @@
+# Visionary Dream: Living Tarot Art
+# Generates a museum-quality piece of visionary art inspired by surrealism and Alex Grey using only the Python standard library.
+
+import math
+import struct
+import zlib
+
+# Canvas configuration
+WIDTH, HEIGHT = 512, 512
+
+# Build pixel array with psychedelic symmetry
+pixels = []
+for y in range(HEIGHT):
+    row = []
+    for x in range(WIDTH):
+        # Normalized coordinates centered at zero
+        nx = (x - WIDTH / 2) / (WIDTH / 2)
+        ny = (y - HEIGHT / 2) / (HEIGHT / 2)
+        r = math.hypot(nx, ny)
+        angle = math.atan2(ny, nx)
+        # Surreal color waves inspired by Alex Grey's palette
+        red = int(255 * (0.5 + 0.5 * math.sin(6 * r - 2 * angle)))
+        green = int(255 * (0.5 + 0.5 * math.sin(6 * r - 2 * angle + 2.094)))
+        blue = int(255 * (0.5 + 0.5 * math.sin(6 * r - 2 * angle + 4.188)))
+        row.extend([red, green, blue])
+    pixels.append(bytes(row))
+
+# Minimal PNG writer
+
+def write_png(filename, width, height, pixel_rows):
+    # Assemble PNG chunks
+    def chunk(tag, data):
+        return (
+            struct.pack('!I', len(data)) +
+            tag +
+            data +
+            struct.pack('!I', zlib.crc32(tag + data) & 0xffffffff)
+        )
+
+    with open(filename, 'wb') as f:
+        f.write(b'\x89PNG\r\n\x1a\n')  # Signature
+        f.write(chunk(b'IHDR', struct.pack('!2I5B', width, height, 8, 2, 0, 0, 0)))
+        raw = b''.join(b'\x00' + row for row in pixel_rows)  # No filtering
+        f.write(chunk(b'IDAT', zlib.compress(raw)))
+        f.write(chunk(b'IEND', b''))
+
+# Render visionary piece
+write_png('Visionary_Dream.png', WIDTH, HEIGHT, pixels)


### PR DESCRIPTION
## Summary
- connect Codex 144:99 with the Living Tarot System via Liber Arcanae
- implement `visionary_dream.py` using only the Python standard library to avoid external dependencies
- document the standalone art generator in module README

## Testing
- `python liber_arcanae/visionary_dream.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9cc39a67c8328b0c8d25753d0d2cc