### PR TITLE
Expand Liber Arcanae with narrative tarot bridge

### DIFF
--- a/liber_arcanae/README.md
+++ b/liber_arcanae/README.md
@@ -3,5 +3,5 @@
 This module initiates the connection between Codex 144:99 and the Living Tarot System. It houses experimental scripts and artifacts for visionary explorations.
 
 - `visionary_dream.py` – generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey.
-- `visionary_dream.py` – generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey and only the Python standard library.
-- `visionary_dream.py` - generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey.
+- `codex_tarot_bridge.py` – prototype bridge linking Codex 144:99 entries with Tarot cards and producing visionary art.
+- `tarot_story_bridge.py` – binds Codex aspects to tarot metadata and generates narrative seeds for adventure modules.

--- a/liber_arcanae/codex_tarot_bridge.py
+++ b/liber_arcanae/codex_tarot_bridge.py
@@ -1,0 +1,89 @@
+"""Codex 144:99 ↔ Living Tarot Bridge
+Generates visionary art influenced by a tarot card's codex aspects.
+"""
+
+# Imports
+import math
+import struct
+import zlib
+from typing import List, Tuple
+
+
+# Data structures
+class CodexEntry:
+    """Codex 144:99 entry describing archetypal aspects."""
+
+    def __init__(self, identifier: str, aspects: List[str]):
+        self.identifier = identifier
+        self.aspects = aspects
+
+
+class TarotCard:
+    """Living tarot card linked to a codex entry."""
+
+    def __init__(self, name: str, codex: CodexEntry):
+        self.name = name
+        self.codex = codex
+
+
+# Palette generation
+def palette_from_aspects(aspects: List[str]) -> List[Tuple[int, int, int]]:
+    """Rotate Alex Grey-inspired palette based on codex aspects."""
+    base = [
+        (15, 15, 61),   # deep indigo
+        (30, 144, 255), # electric blue
+        (255, 0, 255),  # magenta
+        (255, 136, 0),  # orange
+        (255, 255, 0),  # yellow
+        (0, 255, 0),    # green
+        (255, 255, 255) # white
+    ]
+    shift = sum(ord(ch) for ch in ''.join(aspects)) % len(base)
+    return base[shift:] + base[:shift]
+
+
+# Visionary art renderer
+def render_card(card: TarotCard, width: int = 1024, height: int = 1024) -> None:
+    """Render a visionary piece influenced by the card and save to Visionary_Dream.png."""
+    palette = palette_from_aspects(card.codex.aspects)
+    pixels = []
+    for y in range(height):
+        row = []
+        for x in range(width):
+            # Normalized coordinates centered at zero
+            nx = (x - width / 2) / (width / 2)
+            ny = (y - height / 2) / (height / 2)
+            r = math.hypot(nx, ny)
+            angle = math.atan2(ny, nx)
+            wave = math.sin(6 * r - 2 * angle)
+            idx = int((wave + 1) / 2 * (len(palette) - 1))
+            color = palette[idx]
+            row.extend(color)
+        pixels.append(bytes(row))
+
+    write_png('Visionary_Dream.png', width, height, pixels)
+
+
+# Minimal PNG writer
+def write_png(filename: str, width: int, height: int, pixel_rows: List[bytes]) -> None:
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack('!I', len(data)) +
+            tag +
+            data +
+            struct.pack('!I', zlib.crc32(tag + data) & 0xffffffff)
+        )
+
+    with open(filename, 'wb') as f:
+        f.write(b'\x89PNG\r\n\x1a\n')
+        f.write(chunk(b'IHDR', struct.pack('!2I5B', width, height, 8, 2, 0, 0, 0)))
+        raw = b''.join(b'\x00' + row for row in pixel_rows)
+        f.write(chunk(b'IDAT', zlib.compress(raw)))
+        f.write(chunk(b'IEND', b''))
+
+
+# Demonstration
+if __name__ == "__main__":
+    entry = CodexEntry("144:99", ["fire", "transcendence", "wisdom"])
+    card = TarotCard("Egregore", entry)
+    render_card(card)

--- a/liber_arcanae/tarot_story_bridge.py
+++ b/liber_arcanae/tarot_story_bridge.py
@@ -1,0 +1,42 @@
+"""Tarot Story Bridge
+Connects Codex 144:99 aspects with tarot card metadata to seed a
+choose-your-own-adventure narrative.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from codex_tarot_bridge import CodexEntry, TarotCard
+
+# Narrative snippets mapped to codex aspects
+STORY_SNIPPETS: Dict[str, str] = {
+    "fire": "Flames dance around you, forging a path through the void.",
+    "transcendence": "Your spirit rises, glimpsing realms beyond form.",
+    "wisdom": "An ancient owl speaks in riddles of forgotten stars.",
+}
+
+
+def load_tarot_card(name: str, aspects: List[str]) -> TarotCard:
+    """Load tarot metadata and bind it to Codex aspects."""
+    data_path = Path(__file__).resolve().parents[1] / "assets" / "data" / "tarot_absyssia.json"
+    with open(data_path) as f:
+        tarot_data = json.load(f)
+    card_info = next(card for card in tarot_data if card["name"].lower() == name.lower())
+    codex = CodexEntry("144:99", aspects)
+    return TarotCard(card_info["name"], codex)
+
+
+def generate_story(card: TarotCard) -> str:
+    """Compose a narrative seed using the card's codex aspects."""
+    fragments = [STORY_SNIPPETS.get(a, f"The aspect of {a} guides your steps.") for a in card.codex.aspects]
+    parts = " ".join(fragments)
+    return f"You draw {card.name}. {parts}"
+
+
+if __name__ == "__main__":
+    # Example: bind codex aspects to The Fool and print the narrative seed
+    tarot = load_tarot_card("The Fool", ["fire", "transcendence", "wisdom"])
+    print(generate_story(tarot))


### PR DESCRIPTION
## Summary
- document Liber Arcanae module and add tarot story bridge script
- prototype narrative seed generator binding Codex 144:99 aspects to tarot metadata

## Testing
- `python liber_arcanae/codex_tarot_bridge.py && ls | grep Visionary_Dream.png`
- `python liber_arcanae/tarot_story_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_68b9cce653d08328878addcad74ab7e3