### PR TITLE
Add tarot-informed visionary art generator

### DIFF
--- a/assets/data/tarot_absyssia.json
+++ b/assets/data/tarot_absyssia.json
@@ -7,7 +7,8 @@
     "stylepack": "standard",
     "toneHz": 432,
     "angelId": "Raziel",
-    "daemonId": "Bael"
+    "daemonId": "Bael",
+    "palette": ["#F7E967", "#A9E4EF", "#F9F5E3", "#87C38F", "#2E86AB"]
   },
   {
     "id": 1,
@@ -15,6 +16,7 @@
     "arcana": "major",
     "realm": "absyssia",
     "stylepack": "standard",
-    "toneHz": 480
+    "toneHz": 480,
+    "palette": ["#D62828", "#F77F00", "#FCBF49", "#003049", "#6A4C93"]
   }
 ]

--- a/liber_arcanae/README.md
+++ b/liber_arcanae/README.md
@@ -5,3 +5,4 @@ This module initiates the connection between Codex 144:99 and the Living Tarot S
 - `visionary_dream.py` – generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey.
 - `visionary_dream.py` – generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey and only the Python standard library.
 - `visionary_dream.py` - generates a museum-quality piece of visionary art titled *Visionary_Dream.png*, using a palette inspired by Alex Grey.
+- `tarot_visionary.py` – renders card-specific visionary art using palettes defined in `assets/data/tarot_absyssia.json`.

--- a/liber_arcanae/tarot_visionary.py
+++ b/liber_arcanae/tarot_visionary.py
@@ -1,0 +1,76 @@
+"""\
+✦ Codex 144:99 - preserve original intention
+Tarot-informed visionary art generator.
+"""
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import List
+from PIL import Image, ImageDraw
+
+DATA_FILE = Path(__file__).resolve().parents[1] / "assets" / "data" / "tarot_absyssia.json"
+
+
+def _hex_to_rgb(hex_color: str) -> tuple:
+    """Convert hex color string to RGB tuple."""
+    hex_color = hex_color.lstrip('#')
+    return tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4))
+
+
+def load_card(card_name: str) -> dict:
+    """Load card metadata by name."""
+    cards = json.loads(DATA_FILE.read_text(encoding="utf-8"))
+    for card in cards:
+        if card["name"].lower() == card_name.lower():
+            return card
+    raise ValueError(f"Card '{card_name}' not found")
+
+
+def render(card: dict, width: int, height: int, out_dir: Path) -> Path:
+    """Render visionary art using the card's palette."""
+    colors: List[tuple] = [_hex_to_rgb(c) for c in card.get("palette", [])]
+    if not colors:
+        colors = [(40, 0, 80), (70, 0, 130), (0, 128, 255), (0, 255, 128), (255, 200, 0)]
+
+    img = Image.new("RGB", (width, height), "black")
+    draw = ImageDraw.Draw(img)
+    cx, cy = width // 2, height // 2
+
+    # radiating lines
+    for i in range(360):
+        angle = math.radians(i * card["id"] + card.get("toneHz", 0) / 10)
+        r = i / 360 * (min(width, height) // 2)
+        x = cx + r * math.cos(angle)
+        y = cy + r * math.sin(angle)
+        draw.line((cx, cy, x, y), fill=colors[i % len(colors)], width=2)
+
+    # concentric circles
+    for r in range(40, min(width, height) // 2, 40):
+        draw.ellipse((cx - r, cy - r, cx + r, cy + r), outline=colors[r // 40 % len(colors)], width=3)
+
+    # card name footer
+    draw.text((10, height - 30), card["name"], fill=colors[0])
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    filename = out_dir / f"Visionary_Dream_{card['name'].replace(' ', '_')}.png"
+    img.save(filename)
+    return filename
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate tarot-infused visionary art")
+    parser.add_argument("--card", default="The Fool", help="Tarot card name")
+    parser.add_argument("--width", type=int, default=1024)
+    parser.add_argument("--height", type=int, default=1024)
+    parser.add_argument("--out", default="img", help="Output directory")
+    args = parser.parse_args()
+
+    card = load_card(args.card)
+    path = render(card, args.width, args.height, Path(args.out))
+    print(f"Saved {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand tarot metadata with card-specific color palettes
- add `tarot_visionary.py` to render art from a selected tarot card's palette
- document tarot art generation in `liber_arcanae` README

## Testing
- `python -m py_compile liber_arcanae/tarot_visionary.py`
- `python liber_arcanae/tarot_visionary.py --card "The Fool" --out img` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install pillow` *(fails: Could not find a version that satisfies the requirement pillow)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e61c2c2883289bb580bc87b1bde8