### PR TITLE
Add pillar audit tool

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,8 @@ Tooling for Circuitum 99: Alpha et Omega.
 
 - `moonchild_diff.py` -- proposes PATCH blocks for headers, gate badges, and minimal structure fixes (non-destructive).
 - `visionary_dream.py` -- generates a spiral mandala with an Alex Grey-inspired palette.
-- (future) `pillar_audit.py`, `symbol_coherence.py`
+- `pillar_audit.py` -- audits registry/pillars for completeness and naming coherence.
+- (future) `symbol_coherence.py`
 
 Location (fixed coordinate):
 _Registry Node: Circuitum 99 -- Alpha et Omega / system:scripts / coord: SYS-SCRIPTS

--- a/scripts/pillar_audit.py
+++ b/scripts/pillar_audit.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Pillar Audit Tool
+
+Scans the `main/registry/pillars` directory to verify pillar files
+follow naming conventions and that all 21 pillars exist.
+"""
+
+import re
+from pathlib import Path
+
+# Step 1: Locate pillar directory
+PILLAR_DIR = Path(__file__).resolve().parents[1] / "main" / "registry" / "pillars"
+
+# Step 2: Gather pillar files (exclude index)
+files = [p for p in PILLAR_DIR.iterdir() if p.name != "index.md" and p.is_file()]
+
+# Step 3: Extract pillar numbers from filenames
+pattern = re.compile(r"^(\d{2})_")
+found_numbers = []
+unknown = []
+for f in files:
+    match = pattern.match(f.name)
+    if match:
+        found_numbers.append(int(match.group(1)))
+    elif f.name.startswith("pillar_21"):
+        found_numbers.append(21)
+    else:
+        unknown.append(f.name)
+
+# Step 4: Determine missing pillars from expected 1-21
+expected = set(range(1, 22))
+found = set(found_numbers)
+missing = sorted(expected - found)
+
+# Step 5: Report audit findings
+print(f"Pillar files found: {len(files)}")
+print(f"Identified pillars: {sorted(found)}")
+if missing:
+    print(f"Missing pillars: {missing}")
+else:
+    print("All 21 pillars are present and accounted for.")
+if unknown:
+    print(f"Unrecognized files: {unknown}")


### PR DESCRIPTION
## Summary
- document scripting utilities and add pillar audit tool to ensure pillar registry completeness
- implement `pillar_audit.py` to check numbering and missing pillars

## Testing
- `python3 scripts/pillar_audit.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba4c079ad08328a78f1e53a7d07be1