### PR TITLE
Enrich realm indices and refine visionary art generator

### DIFF
--- a/registry/01_main-narrative/chapters_index.md
+++ b/registry/01_main-narrative/chapters_index.md
@@ -1,6 +1,6 @@
 # Chapters Index
 
-- (placeholder) Book of Abyssia -- opening
-- (placeholder) Circuitum 99: Alpha et Omega -- living spine
+- Book of Abyssia -- Descend through obsidian arches into the abyssal library where shadows whisper forgotten names.
+- Circuitum 99: Alpha et Omega -- Walk the living spine of the cathedral, its runes pulsing like the heartbeat of a slumbering titan.
 
 <!-- lock:saturn -->

--- a/registry/02_grimoire/realms_index.md
+++ b/registry/02_grimoire/realms_index.md
@@ -1,5 +1,5 @@
 # Realms Index
 
-- Isle of Return (placeholder)
+- Isle of Return -- A moonlit shoreline circling an ancient gate that glimmers whenever a pilgrim recalls home.
 
 <!-- lock:saturn -->

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,8 @@ Tooling for Circuitum 99: Alpha et Omega.
 
 - `moonchild_diff.py` -- proposes PATCH blocks for headers, gate badges, and minimal structure fixes (non-destructive).
 - `visionary_dream.py` -- generates a spiral mandala with an Alex Grey-inspired palette.
-- (future) `pillar_audit.py`, `symbol_coherence.py`
+- `pillar_audit.py` -- audits registry/pillars for completeness and naming coherence.
+- (future) `symbol_coherence.py`
 
 Location (fixed coordinate):
 _Registry Node: Circuitum 99 -- Alpha et Omega / system:scripts / coord: SYS-SCRIPTS

--- a/scripts/pillar_audit.py
+++ b/scripts/pillar_audit.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Pillar Audit Tool
+
+Scans the `main/registry/pillars` directory to verify pillar files
+follow naming conventions and that all 21 pillars exist.
+"""
+
+import re
+from pathlib import Path
+
+# Step 1: Locate pillar directory
+PILLAR_DIR = Path(__file__).resolve().parents[1] / "main" / "registry" / "pillars"
+
+# Step 2: Gather pillar files (exclude index)
+files = [p for p in PILLAR_DIR.iterdir() if p.name != "index.md" and p.is_file()]
+
+# Step 3: Extract pillar numbers from filenames
+pattern = re.compile(r"^(\d{2})_")
+found_numbers = []
+unknown = []
+for f in files:
+    match = pattern.match(f.name)
+    if match:
+        found_numbers.append(int(match.group(1)))
+    elif f.name.startswith("pillar_21"):
+        found_numbers.append(21)
+    else:
+        unknown.append(f.name)
+
+# Step 4: Determine missing pillars from expected 1-21
+expected = set(range(1, 22))
+found = set(found_numbers)
+missing = sorted(expected - found)
+
+# Step 5: Report audit findings
+print(f"Pillar files found: {len(files)}")
+print(f"Identified pillars: {sorted(found)}")
+if missing:
+    print(f"Missing pillars: {missing}")
+else:
+    print("All 21 pillars are present and accounted for.")
+if unknown:
+    print(f"Unrecognized files: {unknown}")

--- a/scripts/visionary_dream.py
+++ b/scripts/visionary_dream.py
@@ -1,177 +1,64 @@
-# Visionary Dream Generator
-# Produces museum-quality visionary art using Python + Pillow
+#!/usr/bin/env python3
+"""
+Visionary Dream Generator
+Creates a museum-quality piece of visionary art with a palette inspired by Alex Grey.
+"""
 
-from PIL import Image, ImageDraw
-import math
-import random
 from pathlib import Path
-
-# Step 1: Prepare canvas and output
-WIDTH, HEIGHT = 1024, 1024  # Resolution
-output_path = Path(__file__).resolve().parents[1] / "img" / "Visionary_Dream.png"
-
-# Step 2: Create a midnight backdrop for the vision
-image = Image.new("RGB", (WIDTH, HEIGHT), "black")
-draw = ImageDraw.Draw(image)
-
-# Step 3: Set the psychedelic palette (Alex Grey meets surrealism)
-palette = ["#6A0DAD", "#FF6F61", "#00FFFF", "#FFD700", "#1E90FF"]
-
-# Step 4: Weave radiating symmetry lines from the center
-center = (WIDTH // 2, HEIGHT // 2)
-for i in range(360):
-    angle = math.radians(i * 3)
-    radius = i / 360 * (WIDTH // 2)
-    x = center[0] + radius * math.cos(angle * 2)
-    y = center[1] + radius * math.sin(angle * 2)
-    draw.line([center, (x, y)], fill=palette[i % len(palette)], width=2)
-
-# Step 5: Overlay concentric orbs for layered depth
-for r in range(50, WIDTH // 2, 25):
-    color = random.choice(palette)
-    draw.ellipse([center[0]-r, center[1]-r, center[0]+r, center[1]+r], outline=color, width=3)
-
-# Step 6: Seal the vision as a PNG image
-output_path.parent.mkdir(parents=True, exist_ok=True)
-image.save(output_path)
-import math
+from PIL import Image, ImageDraw, ImageFilter
 import random
-from PIL import Image, ImageDraw
+import math
 
-# Set canvas size
-WIDTH, HEIGHT = 1024, 1024
+# Canvas dimensions (HD resolution)
+WIDTH, HEIGHT = 1920, 1080
 
-# Create base image with black background
-img = Image.new("RGB", (WIDTH, HEIGHT), "black")
-draw = ImageDraw.Draw(img)
-
-# Define color palette inspired by Alex Grey's luminous spectra
-palette = [
-    (32, 0, 64),    # deep indigo
-    (64, 0, 128),   # royal violet
-    (0, 128, 255),  # electric blue
-    (255, 165, 0),  # vibrant orange
-    (255, 255, 0),  # golden yellow
-    (255, 0, 128)   # magenta pulse
-]
-
-# Draw radiating lines for visionary geometry
-center = (WIDTH // 2, HEIGHT // 2)
-for i in range(360):
-    angle = math.radians(i)
-    radius = WIDTH // 2
-    x = center[0] + radius * math.cos(angle)
-    y = center[1] + radius * math.sin(angle)
-    color = palette[i % len(palette)]
-    draw.line([center, (x, y)], fill=color, width=1)
-
-# Overlay concentric circles for mandala symmetry
-for r in range(50, WIDTH // 2, 50):
-    color = palette[r // 50 % len(palette)]
-    bbox = [center[0]-r, center[1]-r, center[0]+r, center[1]+r]
-    draw.ellipse(bbox, outline=color)
-
-# Add randomized star-like points for organic patterning
-for _ in range(2000):
-    x = random.randint(0, WIDTH-1)
-    y = random.randint(0, HEIGHT-1)
-    color = random.choice(palette)
-    draw.point((x, y), fill=color)
-
-# Save final image
-img.save("Visionary_Dream.png")
-import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap
-
+# Output path
+OUTPUT = Path(__file__).resolve().parents[1] / "img" / "Visionary_Dream.png"
 
 def main() -> None:
-    """Generate a spiral mandala with an Alex Grey-inspired palette."""
-    # -- Visionary Dream generator --
-    # Resolution for museum-quality output
-    WIDTH, HEIGHT = 1024, 1024
+    """Render the visionary scene and save it as an image."""
+    # Step 1: Cosmic dusk gradient backdrop
+    image = Image.new("RGB", (WIDTH, HEIGHT))
+    pixels = image.load()
+    for y in range(HEIGHT):
+        t = y / HEIGHT
+        r = int(30 + 100 * t)
+        g = int(0 + 60 * t)
+        b = int(60 + 180 * t)
+        for x in range(WIDTH):
+            pixels[x, y] = (r, g, b)
 
-    # Create a spectral palette inspired by Alex Grey
-    colors = [
-        (48/255, 0/255, 108/255),   # deep indigo
-        (0/255, 33/255, 105/255),   # cosmic blue
-        (0/255, 148/255, 68/255),   # vivid green
-        (241/255, 243/255, 54/255), # radiant yellow
-        (255/255, 153/255, 0/255),  # luminous orange
-        (208/255, 0/255, 0/255),    # crimson red
-        (115/255, 0/255, 128/255)   # ultraviolet magenta
-    ]
-    cmap = LinearSegmentedColormap.from_list("alex_grey", colors, N=256)
+    # Step 2: Scatter starlight across the sky
+    draw = ImageDraw.Draw(image)
+    for _ in range(1500):
+        x, y = random.randrange(WIDTH), random.randrange(HEIGHT)
+        star = random.choice([(255, 255, 255), (255, 210, 180), (200, 220, 255)])
+        draw.point((x, y), fill=star)
 
-    # Prepare a radial grid for symmetrical patterns
-    x = np.linspace(-4 * np.pi, 4 * np.pi, WIDTH)
-    y = np.linspace(-4 * np.pi, 4 * np.pi, HEIGHT)
-    X, Y = np.meshgrid(x, y)
+    # Step 3: Raise luminous columns of a dream temple
+    center_x = WIDTH // 2
+    for i in range(-3, 4):
+        column_x = center_x + i * 140
+        draw.rectangle([column_x - 20, 400, column_x + 20, HEIGHT - 120], fill=(80, 20, 120))
+        draw.ellipse([column_x - 60, 300, column_x + 60, 420], outline=(255, 215, 0), width=3)
 
-    # Calculate spiral waves to form a mandala
-    R = np.sqrt(X**2 + Y**2)
-    Theta = np.arctan2(Y, X)
-    Z = np.sin(R + Theta * 3) * np.cos(R * 2 - Theta * 5)
+    # Step 4: Spiral energy halo around the sanctuary
+    for angle in range(0, 360, 4):
+        radius = 0
+        for step in range(180):
+            radius += 2
+            x = center_x + radius * math.cos(math.radians(angle + step))
+            y = HEIGHT // 2 + radius * math.sin(math.radians(angle + step))
+            if 0 <= x < WIDTH and 0 <= y < HEIGHT:
+                color = random.choice([(255, 0, 128), (0, 255, 255), (255, 255, 0)])
+                image.putpixel((int(x), int(y)), color)
 
-    # Render the visionary art
-    plt.figure(figsize=(WIDTH/100, HEIGHT/100), dpi=100)
-    plt.axis("off")
-    plt.imshow(Z, cmap=cmap, interpolation="bilinear")
-    plt.tight_layout(pad=0)
+    # Step 5: Gentle blur for ethereal glow
+    image = image.filter(ImageFilter.GaussianBlur(0.8))
 
-    # Save the final image
-    plt.savefig("Visionary_Dream.png", bbox_inches="tight", pad_inches=0)
-
+    # Step 6: Save final piece
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    image.save(OUTPUT)
 
 if __name__ == "__main__":
     main()
-
-import numpy as np
-from PIL import Image, ImageDraw
-import math
-import random
-
-# Canvas dimensions for high-resolution visionary art
-WIDTH, HEIGHT = 1920, 1080
-
-# Color palette inspired by Alex Grey's surreal vision
-PALETTE = [
-    (30, 30, 60),    # deep indigo
-    (60, 90, 150),   # electric blue
-    (120, 180, 200), # aquamarine
-    (200, 100, 150), # magenta glow
-    (240, 240, 200)  # ethereal gold
-]
-
-# Initialize blank canvas
-img = Image.new("RGB", (WIDTH, HEIGHT))
-pixels = img.load()
-
-# Generate layered sine-wave patterns for fractal flow
-for y in range(HEIGHT):
-    for x in range(WIDTH // 2):
-        r = 0
-        for i in range(3):
-            angle = random.random() * 2 * math.pi
-            freq = 0.002 + i * 0.001
-            r += math.sin(freq * (math.cos(angle) * x + math.sin(angle) * y))
-        index = int(abs(r) * len(PALETTE)) % len(PALETTE)
-        color = PALETTE[index]
-        pixels[x, y] = color
-        pixels[WIDTH - 1 - x, y] = color  # mirror for symmetry
-
-# Overlay concentric visionary glyphs
-draw = ImageDraw.Draw(img)
-center = (WIDTH // 2, HEIGHT // 2)
-for radius in range(50, min(WIDTH, HEIGHT) // 2, 80):
-    color = PALETTE[(radius // 80) % len(PALETTE)]
-    bbox = [
-        center[0] - radius,
-        center[1] - radius,
-        center[0] + radius,
-        center[1] + radius,
-    ]
-    draw.ellipse(bbox, outline=color)
-
-# Save the final visionary piece
-img.save("Visionary_Dream.png")


### PR DESCRIPTION
## Summary
- document scripting utilities and add pillar audit tool to ensure pillar registry completeness
- replace realm placeholders with vivid descriptions of abyssal libraries and moonlit shores
- rewrite `visionary_dream.py` to render a high-resolution dream temple with Alex Grey-inspired palette

## Testing
- `python3 scripts/pillar_audit.py`
- `python3 scripts/visionary_dream.py` *(fails: ModuleNotFoundError: No module named 'PIL'; attempted `pip install pillow` but proxy returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4c079ad08328a78f1e53a7d07be1