### PR TITLE
feat: add canvas-based visionary art

### DIFF
--- a/scripts/solfeggio_layered_assets.py
+++ b/scripts/solfeggio_layered_assets.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Generate visionary art and lossless solfeggio tones for 144 nodes.
+
+Each node receives:
+- A high-resolution visionary image inspired by Alex Grey's palette.
+- A lossless WAV tone based on a solfeggio frequency.
+The script defaults to generating assets for all 144 nodes but can be
+limited via ``--count`` for testing.
+"""
+from __future__ import annotations
+
+import math
+import struct
+import wave
+from pathlib import Path
+import shutil
+
+# --- Configuration ---------------------------------------------------------
+WIDTH, HEIGHT = 1024, 1024  # Resolution for each image
+PALETTE = [
+    (48, 0, 108),    # deep indigo
+    (0, 33, 105),    # cosmic blue
+    (0, 148, 68),    # vivid green
+    (241, 243, 54),  # radiant yellow
+    (255, 153, 0),   # luminous orange
+    (208, 0, 0),     # crimson red
+    (115, 0, 128),   # ultraviolet magenta
+]
+SOLFEGGIO = [174, 285, 396, 417, 528, 639, 741, 852, 963]
+FRAMERATE = 48000  # High-quality audio
+DURATION = 2       # seconds
+
+
+# --- Asset Generators -----------------------------------------------------
+def generate_image(node_id: int, out_dir: Path) -> Path:
+    """Create a symmetrical visionary image for the given node in PPM format."""
+    path = out_dir / f"node_{node_id:03d}_vision.ppm"
+    center_x, center_y = WIDTH / 2, HEIGHT / 2
+    with open(path, "w") as f:
+        f.write(f"P3\n{WIDTH} {HEIGHT}\n255\n")
+        for y in range(HEIGHT):
+            for x in range(WIDTH):
+                dx = x - center_x
+                dy = y - center_y
+                angle = math.atan2(dy, dx)
+                dist = math.hypot(dx, dy)
+                line = int((angle % (2 * math.pi)) / (2 * math.pi / 144))
+                ring = int(dist / 20)
+                r, g, b = PALETTE[(line + ring) % len(PALETTE)]
+                f.write(f"{r} {g} {b} ")
+            f.write("\n")
+    if node_id == 1:
+        preview_dir = Path("img")
+        preview_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy(path, preview_dir / "Visionary_Dream.ppm")
+    return path
+
+
+def generate_audio(node_id: int, freq: int, out_dir: Path) -> Path:
+    """Create a lossless WAV tone for the given node."""
+    path = out_dir / f"node_{node_id:03d}_tone.wav"
+    with wave.open(str(path), "w") as wav:
+        wav.setparams((1, 2, FRAMERATE, 0, "NONE", "not compressed"))
+        for i in range(DURATION * FRAMERATE):
+            sample = int(32767 * math.sin(2 * math.pi * freq * i / FRAMERATE))
+            wav.writeframes(struct.pack('<h', sample))
+    return path
+
+
+def generate_node(node_id: int) -> None:
+    """Generate both audio and visual assets for a single node."""
+    out_dir = Path("assets") / f"node_{node_id:03d}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    freq = SOLFEGGIO[(node_id - 1) % len(SOLFEGGIO)]
+    generate_image(node_id, out_dir)
+    generate_audio(node_id, freq, out_dir)
+
+
+# --- Entrypoint ------------------------------------------------------------
+def main(count: int = 144) -> None:
+    for node_id in range(1, count + 1):
+        generate_node(node_id)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate assets for nodes.")
+    parser.add_argument(
+        "--count", type=int, default=144, help="Number of nodes to generate"
+    )
+    args = parser.parse_args()
+    main(args.count)

--- a/scripts/visionary_dream.html
+++ b/scripts/visionary_dream.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Visionary Dream</title>
+  <style>
+    /* Center canvas on dark background */
+    body { background:#000; margin:0; display:flex; justify-content:center; align-items:center; height:100vh; }
+    canvas { border:1px solid #fff; }
+    #save { position:absolute; top:20px; left:20px; }
+  </style>
+</head>
+<body>
+  <!-- Canvas renders the visionary art -->
+  <canvas id="art" width="1024" height="1024"></canvas>
+  <button id="save">Save</button>
+  <script>
+    // Acquire drawing context
+    const canvas = document.getElementById('art');
+    const ctx = canvas.getContext('2d');
+    const W = canvas.width;
+    const H = canvas.height;
+
+    // Paint a radial gradient background inspired by Alex Grey hues
+    const grad = ctx.createRadialGradient(W/2, H/2, 0, W/2, H/2, W/2);
+    grad.addColorStop(0, '#0f0c29');
+    grad.addColorStop(0.5, '#302b63');
+    grad.addColorStop(1, '#24243e');
+    ctx.fillStyle = grad;
+    ctx.fillRect(0, 0, W, H);
+
+    // Draw 144 symmetrical orbiting nodes with vibrant colors
+    ctx.translate(W/2, H/2);
+    const palette = ['#ff4e50','#fc913a','#f9d423','#eae374','#00a8c6','#40c0cb','#f7f4ea'];
+    for (let i = 0; i < 144; i++) {
+      const angle = (Math.PI * 2 * i) / 144;
+      const radius = (i / 144) * (W / 2);
+      ctx.save();
+      ctx.rotate(angle);
+      ctx.fillStyle = palette[i % palette.length];
+      ctx.beginPath();
+      ctx.arc(radius, 0, 12, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    // Enable download of the artwork as Visionary_Dream.png
+    document.getElementById('save').addEventListener('click', () => {
+      const link = document.createElement('a');
+      link.download = 'Visionary_Dream.png';
+      link.href = canvas.toDataURL('image/png');
+      link.click();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML5 canvas demo that generates 144-node visionary art and saves as Visionary_Dream.png

## Testing
- `node -e "require('fs').readFileSync('scripts/visionary_dream.html'); console.log('ok')"`


------
https://chatgpt.com/codex/tasks/task_e_68ba4ba19fc883289a1eea4c49e96650