### PR TITLE
feat(renderer): add static cosmic helix renderer

### DIFF
--- a/cosmogenesis-learning-engine/README_RENDERER.md
+++ b/cosmogenesis-learning-engine/README_RENDERER.md
@@ -1,0 +1,27 @@
+# Cosmic Helix Renderer
+
+Static HTML+Canvas renderer for the Circuitum 99 cosmology. Double‑click `index.html` to view a 1440×900 canvas composed of four calm layers:
+
+1. **Vesica field** – intersecting circles grounding the space.
+2. **Tree‑of‑Life scaffold** – 10 nodes and 22 paths, centered for balance.
+3. **Fibonacci curve** – golden spiral polyline, drawn once for stability.
+4. **Double‑helix lattice** – two phase‑shifted strands with 22 rungs.
+
+## ND‑safe & Offline
+- No animation, no motion loops, no external libraries.
+- Colors come from `data/palette.json`; if missing, a fallback palette is used.
+- Works by opening `index.html` directly in any modern browser.
+
+## Numerology Constants
+Geometry routines are parameterized by sacred numbers: 3, 7, 9, 11, 22, 33, 99, 144. Adjusting these values alters scale but keeps symbolic meaning.
+
+## File Tree
+```
+cosmogenesis-learning-engine/
+├─ index.html
+├─ js/
+│  └─ helix-renderer.mjs
+├─ data/
+│  └─ palette.json
+└─ README_RENDERER.md
+```

--- a/cosmogenesis-learning-engine/data/palette.json
+++ b/cosmogenesis-learning-engine/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/cosmogenesis-learning-engine/index.html
+++ b/cosmogenesis-learning-engine/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/cosmogenesis-learning-engine/js/helix-renderer.mjs
+++ b/cosmogenesis-learning-engine/js/helix-renderer.mjs
@@ -1,0 +1,158 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine strands)
+
+  Why ND-safe: renders once, no motion; calm colors; each layer isolated for sensory clarity.
+*/
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.save();
+
+  // background
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5] || palette.ink, NUM);
+
+  ctx.restore();
+}
+
+// L1 Vesica field
+function drawVesica(ctx, w, h, color, NUM) {
+  const r = Math.min(w, h) / NUM.THREE; // scale from numerology 3
+  const offset = r;
+  const cy = h / 2;
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+
+  // three pairs across the canvas (left, center, right)
+  for (let i = -1; i <= 1; i++) {
+    const cxL = w / 2 + i * offset - r / 2;
+    const cxR = w / 2 + i * offset + r / 2;
+    ctx.beginPath();
+    ctx.arc(cxL, cy, r, 0, Math.PI * 2);
+    ctx.arc(cxR, cy, r, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+// L2 Tree-of-Life scaffold (simplified geometry)
+function drawTreeOfLife(ctx, w, h, pathColor, nodeColor, NUM) {
+  const nodes = [
+    [0.5, 0.05], // Keter
+    [0.75, 0.18], [0.25, 0.18], // Chokmah, Binah
+    [0.75, 0.35], [0.25, 0.35], // Chesed, Geburah
+    [0.5, 0.5], // Tiferet
+    [0.75, 0.65], [0.25, 0.65], // Netzach, Hod
+    [0.5, 0.8], // Yesod
+    [0.5, 0.95] // Malkuth
+  ];
+
+  const px = nodes.map(n => [n[0] * w, n[1] * h]);
+  const edges = [
+    [0,1],[0,2],[1,2],
+    [1,3],[1,5],[2,4],[2,5],
+    [3,4],[3,5],[4,5],
+    [3,6],[4,7],[5,6],[5,7],
+    [6,8],[7,8],
+    [8,9],
+    [3,7],[4,6]
+  ];
+  // add extra paths to reach 22 total connections (22 = Hebrew letters)
+  edges.push([1,4],[2,3],[6,7]);
+
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 2;
+  for (const [a, b] of edges) {
+    ctx.beginPath();
+    ctx.moveTo(px[a][0], px[a][1]);
+    ctx.lineTo(px[b][0], px[b][1]);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = nodeColor;
+  const r = Math.min(w, h) / NUM.NINETYNINE; // small node size from numerology 99
+  for (const [x, y] of px) {
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+// L3 Fibonacci spiral (static polyline)
+function drawFibonacci(ctx, w, h, color, NUM) {
+  const cx = w / 2;
+  const cy = h / 2;
+  const points = [];
+  const steps = NUM.ONEFORTYFOUR; // 144 = completion cycle
+  const growth = 1.61803398875; // golden ratio
+
+  for (let i = 0; i <= steps; i += NUM.THREE) { // step by 3 for smoothness
+    const angle = (i / NUM.TWENTYTWO) * Math.PI * 2;
+    const radius = Math.pow(growth, i / NUM.ELEVEN);
+    points.push([cx + radius * Math.cos(angle), cy + radius * Math.sin(angle)]);
+  }
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let i = 0; i < points.length; i++) {
+    const [x, y] = points[i];
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+// L4 Double-helix lattice (static, no motion)
+function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+  const mid = h / 2;
+  const amp = h / NUM.NINE;
+  const turns = NUM.THREE; // triple twist
+  const step = w / NUM.ONEFORTYFOUR; // resolution
+
+  // strand A
+  ctx.strokeStyle = colorA;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let x = 0; x <= w; x += step) {
+    const t = (x / w) * turns * Math.PI * 2;
+    const y = mid + amp * Math.sin(t);
+    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // strand B (phase shift by π)
+  ctx.strokeStyle = colorB;
+  ctx.beginPath();
+  for (let x = 0; x <= w; x += step) {
+    const t = (x / w) * turns * Math.PI * 2;
+    const y = mid + amp * Math.sin(t + Math.PI);
+    if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // lattice rungs using 22 segments
+  ctx.strokeStyle = colorA;
+  const rungStep = w / NUM.TWENTYTWO;
+  for (let x = 0; x <= w; x += rungStep) {
+    const t = (x / w) * turns * Math.PI * 2;
+    const y1 = mid + amp * Math.sin(t);
+    const y2 = mid + amp * Math.sin(t + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+}
+


### PR DESCRIPTION
## Summary
- add ND-safe canvas renderer with Vesica, Tree-of-Life, Fibonacci, and double helix layers
- provide palette data and usage notes

## Testing
- `node main/04_registry-meta/integrity-check.mjs` *(module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8949ac548328b0fd0298b46b7232