### PR TITLE
feat(renderer): add static cosmic helix canvas

### DIFF
--- a/cosmogenesis-learning-engine/README_RENDERER.md
+++ b/cosmogenesis-learning-engine/README_RENDERER.md
@@ -1,0 +1,17 @@
+# Cosmic Helix Renderer
+
+Static, ND-safe renderer for layered sacred geometry.
+
+## Use
+- Open `index.html` directly in a browser (double-click).
+- No network requests or dependencies; works offline.
+- Layers: Vesica field, Tree-of-Life scaffold, Fibonacci curve, static double-helix lattice.
+
+## ND-safe choices
+- Calm palette and generous spacing for sensory comfort.
+- No motion, autoplay, or external scripts.
+- Geometry parameters use numerology constants: 3, 7, 9, 11, 22, 33, 99, 144.
+
+## Development
+- Edit `data/palette.json` to adjust colors.
+- `js/helix-renderer.mjs` keeps functions small and well-commented.

--- a/cosmogenesis-learning-engine/data/palette.json
+++ b/cosmogenesis-learning-engine/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/cosmogenesis-learning-engine/index.html
+++ b/cosmogenesis-learning-engine/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/cosmogenesis-learning-engine/js/helix-renderer.mjs
+++ b/cosmogenesis-learning-engine/js/helix-renderer.mjs
@@ -1,0 +1,131 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine waves with rungs)
+
+  All geometry uses calm colors and no motion for ND safety.
+*/
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTreeOfLife(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+}
+
+function drawVesica(ctx, w, h, color, NUM) {
+  // Vesica Piscis: two circles intersecting; ratio uses 7 for gentle spacing
+  const r = Math.min(w, h) / NUM.SEVEN;
+  const cx = w / 2;
+  const cy = h / 2;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(cx - r / 2, cy, r, 0, Math.PI * 2);
+  ctx.arc(cx + r / 2, cy, r, 0, Math.PI * 2);
+  ctx.stroke();
+}
+
+function drawTreeOfLife(ctx, w, h, nodeColor, pathColor, NUM) {
+  // Simplified sephirot layout; proportioned with numerology constants
+  const nodes = [
+    [0.5, 0.08],
+    [0.33, 0.18], [0.67, 0.18],
+    [0.33, 0.38], [0.67, 0.38],
+    [0.33, 0.58], [0.67, 0.58],
+    [0.33, 0.78], [0.67, 0.78],
+    [0.5, 0.88]
+  ];
+
+  const paths = [
+    [0, 1], [0, 2], [1, 2], [1, 3], [2, 4],
+    [3, 4], [3, 5], [4, 6], [5, 6], [5, 7],
+    [6, 8], [7, 8], [7, 9], [8, 9], [1, 4],
+    [2, 3], [3, 8], [4, 7], [1, 6], [2, 5],
+    [3, 9], [4, 9]
+  ];
+
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 1;
+  for (const [a, b] of paths) {
+    const [ax, ay] = nodes[a];
+    const [bx, by] = nodes[b];
+    ctx.beginPath();
+    ctx.moveTo(ax * w, ay * h);
+    ctx.lineTo(bx * w, by * h);
+    ctx.stroke();
+  }
+
+  ctx.fillStyle = nodeColor;
+  const r = NUM.THREE; // small nodes for low visual load
+  for (const [nx, ny] of nodes) {
+    ctx.beginPath();
+    ctx.arc(nx * w, ny * h, r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+function drawFibonacci(ctx, w, h, color, NUM) {
+  // Log spiral using 99 points; phi controls growth (no motion)
+  const cx = w / 2;
+  const cy = h / 2;
+  const steps = NUM.NINETYNINE;
+  const turns = NUM.THREE; // three full turns
+  const scale = Math.min(w, h) / NUM.TWENTYTWO; // gentle size
+  const phi = (1 + Math.sqrt(5)) / 2;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let i = 0; i <= steps; i++) {
+    const t = (i / steps) * turns * Math.PI * 2;
+    const r = scale * Math.pow(phi, t / (Math.PI * 2));
+    const x = cx + r * Math.cos(t);
+    const y = cy + r * Math.sin(t);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+  // Static double helix: two sine waves with 22 rungs
+  const steps = NUM.NINETYNINE;
+  const amplitude = h / NUM.ELEVEN;
+  const baseY = h / 2;
+  ctx.lineWidth = 1.5;
+
+  const wave = (color, phase) => {
+    ctx.strokeStyle = color;
+    ctx.beginPath();
+    for (let i = 0; i <= steps; i++) {
+      const t = i / steps;
+      const x = t * w;
+      const y = baseY + Math.sin(t * NUM.THIRTYTHREE + phase) * amplitude;
+      if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+  };
+
+  wave(colorA, 0);
+  wave(colorB, Math.PI);
+
+  ctx.strokeStyle = colorB;
+  for (let i = 0; i <= NUM.TWENTYTWO; i++) {
+    const t = i / NUM.TWENTYTWO;
+    const x = t * w;
+    const y1 = baseY + Math.sin(t * NUM.THIRTYTHREE) * amplitude;
+    const y2 = baseY + Math.sin(t * NUM.THIRTYTHREE + Math.PI) * amplitude;
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+}


### PR DESCRIPTION
## Summary
- add offline index and renderer for layered vesica, tree-of-life, fibonacci, and helix lattice
- include ND-safe palette data and usage docs

## Testing
- `node main/04_registry-meta/integrity-check.mjs` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba88db382883289d380ed2e707aac4