### PR TITLE
Add offline cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,23 @@
+# Cosmic Helix Renderer
+
+Static, offline renderer for layered sacred geometry. Double-click `index.html` in any modern browser.
+
+## Layers
+1. **Vesica field** – intersecting circles as foundation.
+2. **Tree-of-Life scaffold** – ten sephirot with twenty-two paths.
+3. **Fibonacci curve** – calm log spiral polyline.
+4. **Double-helix lattice** – two static strands with gentle rungs.
+
+## Palette
+Colors are loaded from `data/palette.json`. If the file is missing, the renderer falls back to a built-in ND-safe palette and notes this in the header.
+
+## ND-Safety
+- No animation or motion.
+- Soft contrast on dark background for low visual strain.
+- Static `<canvas>` only; no external requests.
+
+## Numerology
+Geometry routines use constants `3, 7, 9, 11, 22, 33, 99, 144` to keep alignment with the wider cathedral canon.
+
+## Use
+No build step or server. Open `index.html` directly.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg": "#0b0b12",
+  "ink": "#e8e8f0",
+  "layers": ["#b1c7ff", "#89f7fe", "#a0ffa1", "#ffd27f", "#f5a3ff", "#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,145 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted strands with rungs)
+
+  ND-safe rationale:
+    - All geometry is static. No motion or flashing.
+    - Soft palette supplied by data/palette.json (or safe fallback).
+    - Layer order is deliberate: foundational Vesica up to helix lattice.
+*/
+
+export function renderHelix(ctx, { width, height, palette, NUM }) {
+  // Clear + fill background using palette.bg to avoid flicker
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], palette.ink, NUM);
+  drawFibonacci(ctx, width, height, palette.layers[2], NUM);
+  drawHelixLattice(ctx, width, height, palette.layers[3], palette.layers[4], NUM);
+}
+
+function drawVesica(ctx, w, h, color, NUM) {
+  // Two intersecting circles echoing the Vesica Piscis; repeated vertically.
+  const r = Math.min(w, h) / NUM.THREE; // uses constant 3
+  const cx = w / 2;
+  const cy = h / 2;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  for (let i = -1; i <= 1; i++) {
+    const y = cy + (i * r) / NUM.SEVEN; // vertical repetition keyed to 7
+    ctx.beginPath();
+    ctx.arc(cx - r / 2, y, r, 0, Math.PI * 2);
+    ctx.arc(cx + r / 2, y, r, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+}
+
+function drawTree(ctx, w, h, color, nodeColor, NUM) {
+  // Simplified Tree of Life layout; positions are fractional.
+  const nodes = [
+    { x: 0.5, y: 0.07 }, // Keter
+    { x: 0.75, y: 0.18 }, // Chokmah
+    { x: 0.25, y: 0.18 }, // Binah
+    { x: 0.75, y: 0.35 }, // Chesed
+    { x: 0.25, y: 0.35 }, // Geburah
+    { x: 0.5, y: 0.5 },  // Tiphereth
+    { x: 0.75, y: 0.65 }, // Netzach
+    { x: 0.25, y: 0.65 }, // Hod
+    { x: 0.5, y: 0.78 }, // Yesod
+    { x: 0.5, y: 0.92 }  // Malkuth
+  ];
+
+  const edges = [
+    [0,1],[0,2], [1,2], [1,3], [1,6],
+    [2,4],[2,7], [3,4], [3,5], [4,5],
+    [3,6],[4,7], [5,6], [5,7], [6,7],
+    [6,8],[7,8], [5,8], [8,9],[5,9],
+    [3,7],[4,6]
+  ]; // 22 paths
+
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1.5;
+  edges.forEach(([a, b]) => {
+    ctx.beginPath();
+    ctx.moveTo(nodes[a].x * w, nodes[a].y * h);
+    ctx.lineTo(nodes[b].x * w, nodes[b].y * h);
+    ctx.stroke();
+  });
+
+  ctx.fillStyle = nodeColor;
+  const r = NUM.NINE / 3; // node radius tuned by 9
+  nodes.forEach((n) => {
+    ctx.beginPath();
+    ctx.arc(n.x * w, n.y * h, r, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function drawFibonacci(ctx, w, h, color, NUM) {
+  // Log spiral inspired by Fibonacci; drawn as polyline.
+  const center = { x: w / 2, y: h / 2 };
+  const steps = NUM.THIRTYTHREE; // 33 segments
+  const phi = (1 + Math.sqrt(5)) / 2; // golden ratio
+  const scale = (Math.min(w, h) / NUM.ONEFORTYFOUR) * NUM.THIRTYTHREE; // involves 144
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let i = 0; i < steps; i++) {
+    const angle = (i / NUM.ELEVEN) * Math.PI * 2; // turn by 1/11 of a turn per step
+    const radius = scale * Math.pow(phi, i / NUM.TWENTYTWO);
+    const x = center.x + radius * Math.cos(angle);
+    const y = center.y + radius * Math.sin(angle);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+function drawHelixLattice(ctx, w, h, colorA, colorB, NUM) {
+  // DNA-like double helix rendered statically with lattice rungs.
+  const midY = h / 2;
+  const amplitude = h / NUM.SEVEN; // height tuned by 7
+  const segments = NUM.NINETYNINE; // detail level 99
+  const freq = NUM.NINE; // wave count along width
+  const step = w / segments;
+
+  ctx.lineWidth = 1;
+  // strand A
+  ctx.strokeStyle = colorA;
+  ctx.beginPath();
+  for (let i = 0; i <= segments; i++) {
+    const x = i * step;
+    const y = midY + amplitude * Math.sin((i / segments) * freq * Math.PI * 2);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // strand B (phase-shifted by PI)
+  ctx.strokeStyle = colorB;
+  ctx.beginPath();
+  for (let i = 0; i <= segments; i++) {
+    const x = i * step;
+    const y = midY + amplitude * Math.sin((i / segments) * freq * Math.PI * 2 + Math.PI);
+    if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+
+  // lattice rungs every 11 segments
+  ctx.strokeStyle = colorB;
+  for (let i = 0; i <= segments; i += NUM.ELEVEN) {
+    const x = i * step;
+    const y1 = midY + amplitude * Math.sin((i / segments) * freq * Math.PI * 2);
+    const y2 = midY + amplitude * Math.sin((i / segments) * freq * Math.PI * 2 + Math.PI);
+    ctx.beginPath();
+    ctx.moveTo(x, y1);
+    ctx.lineTo(x, y2);
+    ctx.stroke();
+  }
+}


### PR DESCRIPTION
## Summary
- add ND-safe canvas renderer for Vesica, Tree-of-Life, Fibonacci, and static double helix
- supply palette and docs for offline use

## Testing
- `./scripts/check.sh` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8d680c24832885bec9363ea2c6a0