### PR TITLE
Add static helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,0 +1,19 @@
+# Cosmic Helix Renderer
+
+Static HTML+Canvas renderer for layered sacred geometry.  Designed for offline use and neurodivergent safety.
+
+## Layers
+1. **Vesica field** – intersecting circles in a calm grid.
+2. **Tree-of-Life scaffold** – ten nodes with twenty-two connecting paths.
+3. **Fibonacci curve** – golden ratio spiral drawn once.
+4. **Double-helix lattice** – two sine waves with gentle cross-links.
+
+## Use
+Open `index.html` in any modern browser.  No build step, server, or external network is required.
+
+If `data/palette.json` is missing, the renderer falls back to a safe default palette and shows a short notice at the top of the page.
+
+## Notes
+- All geometry constants are exposed in the `NUM` object: 3, 7, 9, 11, 22, 33, 99, 144.
+- Color and layer order favor high readability, soft contrast, and no motion.
+- Files use UTF-8, LF newlines, ASCII quotes, and contain no dependencies or animation libraries.

--- a/data/palette.json
+++ b/data/palette.json
@@ -1,0 +1,5 @@
+{
+  "bg":"#0b0b12",
+  "ink":"#e8e8f0",
+  "layers":["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cosmic Helix Renderer (ND-safe, Offline)</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="color-scheme" content="light dark">
+  <style>
+    /* ND-safe: calm contrast, no motion, generous spacing */
+    :root { --bg:#0b0b12; --ink:#e8e8f0; --muted:#a6a6c1; }
+    html,body { margin:0; padding:0; background:var(--bg); color:var(--ink); font:14px/1.4 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+    header { padding:12px 16px; border-bottom:1px solid #1d1d2a; }
+    .status { color:var(--muted); font-size:12px; }
+    #stage { display:block; margin:16px auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { max-width:900px; margin:0 auto 16px; color:var(--muted); }
+    code { background:#11111a; padding:2px 4px; border-radius:3px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette…</div>
+  </header>
+
+  <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
+  <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
+
+    const elStatus = document.getElementById("status");
+    const canvas = document.getElementById("stage");
+    const ctx = canvas.getContext("2d");
+
+    async function loadJSON(path) {
+      try {
+        const res = await fetch(path, { cache: "no-store" });
+        if (!res.ok) throw new Error(String(res.status));
+        return await res.json();
+      } catch (err) {
+        return null;
+      }
+    }
+
+    const defaults = {
+      palette: {
+        bg:"#0b0b12",
+        ink:"#e8e8f0",
+        layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
+      }
+    };
+
+    const palette = await loadJSON("./data/palette.json");
+    const active = palette || defaults.palette;
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    // Numerology constants used by geometry routines
+    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+
+    // ND-safe rationale: no motion, high readability, soft colors, layered order
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+  </script>
+</body>
+</html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,0 +1,123 @@
+/*
+  helix-renderer.mjs
+  ND-safe static renderer for layered sacred geometry.
+
+  Layers:
+    1) Vesica field (intersecting circles)
+    2) Tree-of-Life scaffold (10 sephirot + 22 paths; simplified layout)
+    3) Fibonacci curve (log spiral polyline; static)
+    4) Double-helix lattice (two phase-shifted sine curves)
+  The routines favor calm colors and avoid motion.
+*/
+
+export function renderHelix(ctx, opts) {
+  const { width, height, palette, NUM } = opts;
+  ctx.fillStyle = palette.bg;
+  ctx.fillRect(0, 0, width, height);
+  drawVesica(ctx, width, height, palette.layers[0], NUM);
+  drawTree(ctx, width, height, palette.layers[1], palette.layers[2], NUM);
+  drawFibonacci(ctx, width, height, palette.layers[3], NUM);
+  drawHelix(ctx, width, height, palette.layers[4], palette.layers[5], NUM);
+}
+
+// Layer 1: Vesica grid
+function drawVesica(ctx, w, h, color, NUM) {
+  // ND-safe: thin lines and roomy spacing keep the field gentle.
+  const step = w / NUM.TWENTYTWO;
+  const r = step;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 1;
+  for (let y = r; y < h; y += step) {
+    for (let x = r; x < w; x += step) {
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.stroke();
+    }
+  }
+}
+
+// Layer 2: Tree-of-Life scaffold
+function drawTree(ctx, w, h, pathColor, nodeColor, NUM) {
+  // Simplified placement, centered to aid focus.
+  const nodes = [
+    { x: 0.5, y: 0.05 },
+    { x: 0.7, y: 0.18 },
+    { x: 0.3, y: 0.18 },
+    { x: 0.7, y: 0.36 },
+    { x: 0.3, y: 0.36 },
+    { x: 0.5, y: 0.5 },
+    { x: 0.7, y: 0.64 },
+    { x: 0.3, y: 0.64 },
+    { x: 0.5, y: 0.77 },
+    { x: 0.5, y: 0.9 }
+  ].map(n => ({ x: n.x * w, y: n.y * h }));
+  const paths = [
+    [0, 1], [0, 2], [1, 2], [1, 3], [2, 4], [3, 4], [3, 5], [4, 5],
+    [3, 6], [4, 7], [6, 7], [6, 8], [7, 8], [8, 9], [5, 6], [5, 7],
+    [5, 8], [1, 6], [2, 7], [0, 5], [2, 6], [1, 7]
+  ];
+  ctx.strokeStyle = pathColor;
+  ctx.lineWidth = 2;
+  paths.forEach(p => {
+    ctx.beginPath();
+    ctx.moveTo(nodes[p[0]].x, nodes[p[0]].y);
+    ctx.lineTo(nodes[p[1]].x, nodes[p[1]].y);
+    ctx.stroke();
+  });
+  ctx.fillStyle = nodeColor;
+  const r = Math.min(w, h) / NUM.THIRTYTHREE;
+  nodes.forEach(n => {
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, r, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+// Layer 3: Fibonacci curve
+function drawFibonacci(ctx, w, h, color, NUM) {
+  // Static log spiral using the golden ratio; no animation.
+  const phi = (1 + Math.sqrt(5)) / 2;
+  const cx = w / 2, cy = h / 2;
+  const r0 = Math.min(w, h) / NUM.ONEFORTYFOUR;
+  const maxTheta = NUM.NINE * Math.PI / NUM.THREE; // ~3π
+  const step = maxTheta / NUM.NINETYNINE;
+  ctx.strokeStyle = color;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  for (let theta = 0; theta <= maxTheta; theta += step) {
+    const r = r0 * Math.pow(phi, theta / (Math.PI / 2));
+    const x = cx + r * Math.cos(theta);
+    const y = cy + r * Math.sin(theta);
+    if (theta === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+  }
+  ctx.stroke();
+}
+
+// Layer 4: Double-helix lattice
+function drawHelix(ctx, w, h, colorA, colorB, NUM) {
+  // Two phase-shifted sine waves; vertical links create a lattice.
+  const step = w / NUM.NINETYNINE;
+  const amp = h / 4;
+  const freq = NUM.TWENTYTWO * Math.PI / w;
+  const helix = (phase, color) => {
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    for (let x = 0; x <= w; x += step) {
+      const y = h / 2 + Math.sin(freq * x + phase) * amp;
+      if (x === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+    return x => h / 2 + Math.sin(freq * x + phase) * amp;
+  };
+  const y1 = helix(0, colorA);
+  const y2 = helix(Math.PI, colorB);
+  ctx.strokeStyle = colorB;
+  ctx.lineWidth = 1;
+  for (let x = 0; x <= w; x += step * NUM.ELEVEN) {
+    ctx.beginPath();
+    ctx.moveTo(x, y1(x));
+    ctx.lineTo(x, y2(x));
+    ctx.stroke();
+  }
+}


### PR DESCRIPTION
## Summary
- add offline HTML canvas renderer for vesica field, tree of life, fibonacci spiral, and double-helix lattice
- include safe color palette and documentation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba73fbb5fc8328a0a9c8b2ddae7b52