### PR TITLE
doc: map systems and game modules

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,32 @@
+# Circuitum99 Integration Tasks
+
+Summary of current state and next steps for linking repos, games, and world-building tools.
+
+## Completed
+- **Cosmic Helix Renderer** (`index.html`, `js/helix-renderer.mjs`)
+  - Offline, ND-safe canvas with Vesica, Tree, Fibonacci, and static helix layers.
+  - Loads palette and crystal data from `data/` with graceful fallbacks.
+- **LuxCrux V Engine** (`games/luxcrux_v/engine.py`)
+  - CLI adventure runner with hooks for dynamic art and music.
+- **Registry scaffolding** (`registry/`)
+  - Initial indexes for characters, systems, and narrative nodes.
+
+## Current Repo Links
+- `Circuitum99` (soul) hosts the codex and world lore.
+- `Cosmogenesis Learning Engine` (mind) is referenced by game hooks for generative media.
+- `Stone Cathedral` (body) contains spatial/asset work (external repo referenced in docs).
+- Game modules live under `games/` and reference the mind layer via hooks.
+
+## Expansion for Multiple Games & Complex Environments
+- Define a common **API contract** for `trigger_art` / `trigger_music` so any game can request media from the mind layer.
+- Extend the **registry** to index game modules, scenes, and assets for cross-game reuse.
+- Provide **world node metadata** (e.g., location, theme, palette) so the renderer can visualize any node.
+- Offer a **JSON schema** for games to register themselves and their hooks.
+
+## Outstanding Work
+- Implement the `trigger_art` and `trigger_music` hooks to call the Cosmogenesis Learning Engine or another ND-safe renderer.
+- Replace `games/visionary_dream.py` Pillow script with a pure-canvas or NumPy alternative.
+- Populate `registry/` with full lists of systems, characters, and node connections.
+- Add more game modules and ensure they read from shared registry data.
+- Document how to contribute new layers, palettes, and numerology constants.
+

--- a/games/registry.md
+++ b/games/registry.md
@@ -1,0 +1,17 @@
+# Game Modules Registry
+
+Catalog of playable or experimental game engines within the cathedral.
+
+## LuxCrux V
+- **Path:** `games/luxcrux_v`
+- **Type:** CLI choose-your-own-adventure.
+- **Hooks:** `trigger_art` and `trigger_music` connect scenes to the Cosmogenesis Learning Engine for generative media.
+
+## CYOA
+- **Path:** `games/cyoa/circuitum99.ink`
+- **Type:** Ink script prototype awaiting an interpreter.
+
+## Visionary Dream
+- **Path:** `games/visionary_dream.py`
+- **Type:** Generative art study. Currently uses Pillow; replace with ND-safe renderer in future.
+

--- a/registry/systems_index.md
+++ b/registry/systems_index.md
@@ -1,5 +1,10 @@
 # Systems (Angelic Tech) Index
 
-- (none found)
+The cathedral spans mind, body, and soul modules. Known systems include:
+
+- **Circuitum 99** — soul layer codex of nodes and lore.
+- **Cosmogenesis Learning Engine** — mind layer for generative art and music hooks.
+- **Stone Cathedral** — body layer of physical spaces and assets.
+- **LuxCrux V** — minimal game engine linking scenes to the mind layer.
 
 <!-- lock:saturn -->


### PR DESCRIPTION
## Summary
- outline current systems linking soul, mind, body, and game layers
- catalog existing game modules and their hooks for generative media
- record integration tasks for multi-game world building

## Testing
- `python -m py_compile games/luxcrux_v/engine.py`
- `node -e "import('./js/helix-renderer.mjs').then(()=>console.log('loaded'))"`


------
https://chatgpt.com/codex/tasks/task_e_68bcc5bb03188328a859059c6b1c30f3