### PR TITLE
Refine ND-safe helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -7,12 +7,9 @@ Static, offline renderer for layered sacred geometry. Double-click `index.html` 
 2. **Tree-of-Life scaffold** – ten sephirot with twenty-two paths.
 3. **Fibonacci curve** – calm log spiral polyline.
 4. **Double-helix lattice** – two static strands with gentle rungs.
-5. **Crystal nodes** – optional points carrying real-world frequency data.
 
 ## Palette
 Colors are loaded from `data/palette.json`. If the file is missing, the renderer falls back to a built-in ND-safe palette and notes this in the header.
-
-Crystal metadata is loaded from `data/crystals.json`. Missing file results in no crystals and a notice.
 
 Layer colors map as follows:
 - `layers[0]` – Vesica field
@@ -21,7 +18,6 @@ Layer colors map as follows:
 - `layers[3]` – Fibonacci curve
 - `layers[4]` – Helix strand A
 - `layers[5]` – Helix strand B
-- crystals use their own `color` field
 
 ## ND-Safety
 - No animation or motion.
@@ -30,8 +26,6 @@ Layer colors map as follows:
 
 ## Numerology
 Geometry routines use constants `3, 7, 9, 11, 22, 33, 99, 144` to keep alignment with the wider cathedral canon.
-
-Crystal objects have fields `name`, `frequency`, `color`, and normalized `position`.
 
 ## Use
 No build step or server. Open `index.html` directly.

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading resources…</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -47,23 +47,18 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      },
-      crystals: []
+      }
     };
 
     const palette = await loadJSON("./data/palette.json");
-    const crystals = await loadJSON("./data/crystals.json");
     const active = palette || defaults.palette;
-    const stones = crystals || defaults.crystals;
-    elStatus.textContent =
-      (palette ? "Palette loaded." : "Palette missing; using safe fallback.") +
-      (crystals ? " Crystals loaded." : " Crystals missing; none rendered.");
+    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, crystals:stones });
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -13,7 +13,7 @@
                   [3] Fibonacci, [4] helix A, [5] helix B.
   Order matters: background to foreground to preserve depth without motion.
 */
-export function renderHelix(ctx, { width, height, palette, NUM, crystals = [] }) {
+export function renderHelix(ctx, { width, height, palette, NUM }) {
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
   const layers = palette.layers;
@@ -22,7 +22,6 @@ export function renderHelix(ctx, { width, height, palette, NUM, crystals = [] })
   drawTree(ctx, width, height, layers[1], layers[2], NUM);
   drawFibonacci(ctx, width, height, layers[3], NUM);
   drawHelix(ctx, width, height, layers[4], layers[5], NUM);
-  if (crystals.length) drawCrystals(ctx, width, height, crystals, palette.ink);
 }
 
 // 1) Vesica field — foundational duality
@@ -122,22 +121,5 @@ function drawHelix(ctx, w, h, colorA, colorB, NUM) {
     ctx.moveTo(x, y1);
     ctx.lineTo(x, y2);
     ctx.stroke();
-  }
-}
-
-// 5) Crystal nodes — real properties mapped without motion
-function drawCrystals(ctx, w, h, crystals, ink) {
-  ctx.font = "12px system-ui, sans-serif";
-  ctx.textAlign = "center";
-  for (const c of crystals) {
-    const x = c.position.x * w;
-    const y = c.position.y * h;
-    ctx.fillStyle = c.color;
-    ctx.beginPath();
-    ctx.arc(x, y, 6, 0, Math.PI * 2);
-    ctx.fill();
-    // ND-safe: frequency label uses ink color for readability
-    ctx.fillStyle = ink;
-    ctx.fillText(String(c.frequency), x, y - 8);
   }
 }


### PR DESCRIPTION
## Summary
- remove unused crystal data handling from the helix renderer
- load palette only and render Vesica, Tree-of-Life, Fibonacci curve, and static double helix
- document offline, ND-safe usage and layer mapping

## Testing
- `node --check js/helix-renderer.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bcdefb44148328a99ca099c0bfc5da