### PR TITLE
add duplicate line trimmer and tidy helix index

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,11 +49,11 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      }
+      },
+      crystals: []
     };
 
     const palette = await loadJSON("./data/palette.json");
-
     const crystals = await loadJSON("./data/crystals.json");
     await loadBridge();
     const assetBase = getRoute("stone_grimoire", "assets");
@@ -63,10 +63,6 @@
       (palette ? "Palette loaded." : "Palette missing; using safe fallback.") +
       (crystals ? " Crystals loaded." : " Crystals missing; none rendered.") +
       (assetBase ? ` Assets route: ${assetBase}` : " Bridge missing; routes unavailable.");
-
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,7 @@ Tooling for Circuitum 99: Alpha et Omega.
 - `visionary_dream.py` -- generates a spiral mandala with an Alex Grey-inspired palette.
 - `pillar_audit.py` -- audits registry/pillars for completeness and naming coherence.
 - (future) `symbol_coherence.py`
+- `dedupe_lines.py` -- strips consecutive duplicate lines from files.
 
 Location (fixed coordinate):
 _Registry Node: Circuitum 99 -- Alpha et Omega / system:scripts / coord: SYS-SCRIPTS

--- a/scripts/dedupe_lines.py
+++ b/scripts/dedupe_lines.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Remove consecutive duplicate lines from text files.
+
+Memory lapses sometimes append the same block twice.
+This tiny tool keeps files trimmed without any network calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+
+
+def dedupe_file(path: pathlib.Path) -> int:
+    """Collapse runs of identical lines. Return count removed."""
+    data = path.read_text(encoding="utf-8")
+    lines = data.splitlines()
+    cleaned: list[str] = []
+    removed = 0
+    prev: str | None = None
+    for line in lines:
+        if line == prev:
+            removed += 1
+            continue
+        cleaned.append(line)
+        prev = line
+    tail = "\n" if data.endswith("\n") else ""
+    path.write_text("\n".join(cleaned) + tail, encoding="utf-8")
+    return removed
+
+
+def tracked_files() -> list[pathlib.Path]:
+    """List repo-tracked files using git."""
+    res = subprocess.run([
+        "git",
+        "ls-files",
+    ], check=True, text=True, capture_output=True)
+    return [pathlib.Path(line) for line in res.stdout.splitlines()]
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Remove consecutive duplicate lines")
+    p.add_argument("files", nargs="*", type=pathlib.Path, help="Targets")
+    p.add_argument("--all", action="store_true", help="Process all tracked files")
+    args = p.parse_args()
+
+    targets = args.files or []
+    if args.all:
+        targets = tracked_files()
+    if not targets:
+        p.error("no files given")
+
+    for path in targets:
+        removed = dedupe_file(path)
+        if removed:
+            print(f"{path}: removed {removed} duplicate line(s)")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- document new dedupe helper in scripts README
- clean duplicate lines in static renderer index and add crystals fallback
- provide scripts/dedupe_lines.py for trimming consecutive duplicates

## Testing
- `python scripts/dedupe_lines.py index.html`
- `node --check js/helix-renderer.mjs`
- `python -m py_compile scripts/dedupe_lines.py`


------
https://chatgpt.com/codex/tasks/task_e_68be02c6c4b48328828aecae4b25d371