### PR TITLE
Simplify cosmic helix renderer to core layers

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -31,12 +31,3 @@ Geometry routines use constants `3, 7, 9, 11, 22, 33, 99, 144` to keep alignment
 
 ## Use
 No build step or server. Open `index.html` directly.
-
-## Bridge Loader
-`js/bridge-loader.mjs` reads `bridge/c99-bridge.json` and exposes small helpers:
-
-- `loadBridge()` – fetch and parse the bridge file once.
-- `getRoute(repo, key)` – retrieve a path for a given repository and key.
-
-`index.html` uses this to report the `stone_grimoire` assets route, keeping future engines
-consistent when locating shared resources. Missing or invalid bridge data falls back to safe empty objects.

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<!-- Motto: Per Texturas Numerorum, Spira Loquitur. -->
+<!-- Motto: Per Texturas Numerorum, Spira Loquitur -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -26,9 +26,8 @@
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 
-    <script type="module">
-      import { renderHelix } from "./js/helix-renderer.mjs";
-      import { loadBridge, getRoute } from "./js/bridge-loader.mjs";
+  <script type="module">
+    import { renderHelix } from "./js/helix-renderer.mjs";
 
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
@@ -53,20 +52,8 @@
     };
 
     const palette = await loadJSON("./data/palette.json");
-
-    const crystals = await loadJSON("./data/crystals.json");
-    await loadBridge();
-    const assetBase = getRoute("stone_grimoire", "assets");
-    const active = palette || defaults.palette;
-    const stones = crystals || defaults.crystals;
-    elStatus.textContent =
-      (palette ? "Palette loaded." : "Palette missing; using safe fallback.") +
-      (crystals ? " Crystals loaded." : " Crystals missing; none rendered.") +
-      (assetBase ? ` Assets route: ${assetBase}` : " Bridge missing; routes unavailable.");
-
     const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };


### PR DESCRIPTION
## Summary
- streamline `index.html` to load palette with offline fallback and render core Vesica, Tree, Fibonacci, and helix layers
- document renderer usage, palette roles, and ND-safety in `README_RENDERER.md`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be1a53a6c88328a763f2acc12a4060