### PR TITLE
Streamline ND-safe helix renderer index

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 <!doctype html>
-<!-- Motto: Per Texturas Numerorum, Spira Loquitur -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -20,7 +19,7 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -48,23 +47,12 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      },
-      crystals: []
+      }
     };
 
     const palette = await loadJSON("./data/palette.json");
-
-    const crystals = await loadJSON("./data/crystals.json");
-    await loadBridge();
-    const assetBase = getRoute("stone_grimoire", "assets");
     const active = palette || defaults.palette;
-    const stones = crystals || defaults.crystals;
-    elStatus.textContent =
-      (palette ? "Palette loaded." : "Palette missing; using safe fallback.") +
-      (crystals ? " Crystals loaded." : " Crystals missing; none rendered.") +
-      (assetBase    const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };


### PR DESCRIPTION
## Summary
- prune extraneous logic from `index.html` for a pure offline helix renderer
- load palette with fallback and pass numerology constants to the rendering module

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68be37ce8b7c832895100ff6604c40cc