### PR TITLE
Replace helix renderer with modern static canvas

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -2,10 +2,10 @@
 
 Summary of current state and next steps for linking repos, games, and world-building tools.
 
-## Completed
+## Working
 - **Cosmic Helix Renderer** (`index.html`, `js/helix-renderer.mjs`)
-  - Offline, ND-safe canvas with Vesica, Tree, Fibonacci, and static helix layers.
-  - Loads palette and crystal data from `data/` with graceful fallbacks.
+  - Replaced the broken helix script with a modern offline canvas.
+  - Renders Vesica, Tree, Fibonacci, and a static double helix using a palette from `data/` with graceful fallback.
 - **LuxCrux V Engine** (`games/luxcrux_v/engine.py`)
   - CLI adventure runner with hooks for dynamic art and music.
 - **Registry scaffolding** (`registry/`)
@@ -29,4 +29,7 @@ Summary of current state and next steps for linking repos, games, and world-buil
 - Populate `registry/` with full lists of systems, characters, and node connections.
 - Add more game modules and ensure they read from shared registry data.
 - Document how to contribute new layers, palettes, and numerology constants.
+- Build a toggle system so art, learning, and music modes can switch styles.
+- Create identity anchor art for Rebecca Respawn and other avatars before layering fusion effects.
+- Produce book-ready art variants: illuminated manuscript plates, engraved diagrams, visionary scenes, and cinematic frames.
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,4 @@
 <!doctype html>
-<!-- Motto: Per Texturas Numerorum, Spira Loquitur -->
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -20,7 +19,7 @@
 <body>
   <header>
     <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette...</div>
+    <div class="status" id="status">Loading palette…</div>
   </header>
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
@@ -48,23 +47,12 @@
         bg:"#0b0b12",
         ink:"#e8e8f0",
         layers:["#b1c7ff","#89f7fe","#a0ffa1","#ffd27f","#f5a3ff","#d0d0e6"]
-      },
-      crystals: []
+      }
     };
 
     const palette = await loadJSON("./data/palette.json");
-
-    const crystals = await loadJSON("./data/crystals.json");
-    await loadBridge();
-    const assetBase = getRoute("stone_grimoire", "assets");
     const active = palette || defaults.palette;
-    const stones = crystals || defaults.crystals;
-    elStatus.textContent =
-      (palette ? "Palette loaded." : "Palette missing; using safe fallback.") +
-      (crystals ? " Crystals loaded." : " Crystals missing; none rendered.") +
-      (assetBase    const active = palette || defaults.palette;
     elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
-
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };


### PR DESCRIPTION
## Summary
- Swap corrupted helix page for a modern offline HTML+Canvas renderer with ND-safe palette loading
- Update integration task list to show working components and next steps for art and style toggles

## Testing
- `node --check js/helix-renderer.mjs`
- `node -e "import('./js/helix-renderer.mjs').then(m=>console.log(Object.keys(m)))"`


------
https://chatgpt.com/codex/tasks/task_e_68be459185888328a85aad7effc9d08b