### PR TITLE
Add Avalon realm and Fortune protocols

### DIFF
--- a/cosmogenesis-learning-engine/registry/octagram-tesseracts.json
+++ b/cosmogenesis-learning-engine/registry/octagram-tesseracts.json
@@ -1,0 +1,4 @@
+{
+  "realm_links": ["stone-cathedral/realms/avalon/index.md"],
+  "research_links": ["docs/avalon/fortune_index.md"]
+}

--- a/docs/avalon/fortune_index.md
+++ b/docs/avalon/fortune_index.md
@@ -1,0 +1,9 @@
+# Fortune Index
+
+When **OCTA-FORTUNE** activates:
+
+- Companions shift toward seer and guardian behaviors.
+- Pathworking moves through gentle mirror riddles.
+- Psychic hygiene checks occur before any deep dive.
+
+These protocols honor Fortune's calm guidance.

--- a/hooks/onArcanaSwitch.mjs
+++ b/hooks/onArcanaSwitch.mjs
@@ -1,0 +1,10 @@
+// ND-safe: adjusts companion logic without animation or network.
+export function onArcanaSwitch(state, companions) {
+  if (state.arcana === 'OCTA-FORTUNE') {
+    companions.mode = 'seer_guardian';
+    state.pathworking = {
+      style: 'gentle mirror riddles',
+      hygiene: 'psychic checks before deep dives'
+    };
+  }
+}

--- a/stone-cathedral/realms/avalon/index.md
+++ b/stone-cathedral/realms/avalon/index.md
@@ -1,0 +1,15 @@
+# Avalon Moon Court
+
+Soft fade into the Moon Court. Sidebar:
+- [Morgan le Fay Rooms](#morgan-le-fay-rooms)
+- [Isle Fog Pathworking](#isle-fog-pathworking)
+- [Inner Order Vaults](#inner-order-vaults)
+
+## Morgan le Fay Rooms
+Whispering chambers for seer training and guardian counsel.
+
+## Isle Fog Pathworking
+Mists guide gentle steps; riddles mirror the walker.
+
+## Inner Order Vaults
+Quiet archives where inner keys rest.


### PR DESCRIPTION
## Summary
- map Avalon and Fortune docs into octagram tesseracts registry
- seed Avalon Moon Court realm with sidebar links
- document Fortune protocols and Arcana switch companion behavior

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c104a389948328a90d6f8fa3ac6e99