### PR TITLE
Add Shem gate hook and double tree index

### DIFF
--- a/hooks/shem_gate.js
+++ b/hooks/shem_gate.js
@@ -1,0 +1,9 @@
+// Runtime: summon a Shem angel + paired shadow daemon; modulate by Tarot.
+export function openShemGate(index, currentArcana){
+  const angel = `Shem_${String(index).padStart(2,"0")}`;
+  const daemon = `Shadow_${String(index).padStart(2,"0")}`;
+  const mode = (currentArcana.includes("The Tower")) ? "trial" :
+               (currentArcana.includes("Temperance")) ? "reconcile" :
+               (currentArcana.includes("The Star")) ? "heal" : "learn";
+  return { angel, daemon, mode };
+}

--- a/story/double_tree_index.json
+++ b/story/double_tree_index.json
@@ -1,0 +1,7 @@
+{
+  "influences": ["Travis McHenry","Israel Regardie","Timothy Leary","Antero Alli","Phil Hine","Robert Anton Wilson"],
+  "mechanic": "double_tree_climb",
+  "trees": ["Tree of Life","Tree of Depths"],
+  "chapters_by_shem": 72,
+  "pairing_rule": "Each chapter pairs a Shem angel with a shadow daemon. Tarot perspective modulates dialogue, trials, and boons."
+}


### PR DESCRIPTION
## Summary
- Introduce `double_tree_index.json` describing influences and mechanics for a dual-tree climb narrative
- Implement `openShemGate` hook to return Shem angel/daemon pair modulated by Tarot arcana

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c10e8397888328acc05763fec2c7d8