### PR TITLE
docs: add provenance footer for cosmic helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -34,3 +34,5 @@ to keep alignment with the wider cathedral canon.
 ## Use
 No build step or server. Open `index.html` directly.
 
+> Source lineage verified. Assets are atelier_v2 (GLB+EXR). ND-Safe: true. No SVG used. Author: Rebecca Respawn.
+

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
 
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
+  <footer class="note"><small>Source lineage verified. Assets are atelier_v2 (GLB+EXR). ND-Safe: true. No SVG used. Author: Rebecca Respawn.</small></footer>
 
   <script type="module">
     import { renderHelix } from "./js/helix-renderer.mjs";


### PR DESCRIPTION
## Summary
- append provenance footer to offline Cosmic Helix index page
- mirror provenance statement in renderer README

## Testing
- `node --check js/helix-renderer.mjs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4ec4ec2248328a129a954f275e086