### PR TITLE
chore: clean renderer docs

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -1,5 +1,3 @@
-Per Texturas Numerorum, Spira Loquitur.  //
-
 # Cosmic Helix Renderer
 
 Static, offline renderer for layered sacred geometry. Double-click `index.html` in any modern browser.
@@ -34,3 +32,9 @@ to keep alignment with the wider cathedral canon.
 ## Use
 No build step or server. Open `index.html` directly.
 
+
+## Sources
+- Vesica piscis construction from Euclid's Elements (public domain)
+- Fibonacci sequence from Leonardo of Pisa's *Liber Abaci* (1202)
+- Tree-of-Life layout from open Kabbalah diagrams
+- Helix lattice derived from elementary sine waves

--- a/index.html
+++ b/index.html
@@ -1,4 +1,3 @@
-<!-- Per Texturas Numerorum, Spira Loquitur.  // -->
 <!doctype html>
 <html lang="en">
 <head>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -1,4 +1,3 @@
-// Per Texturas Numerorum, Spira Loquitur.  //
 /*
   helix-renderer.mjs
   ND-safe static renderer for layered sacred geometry.


### PR DESCRIPTION
## Summary
- remove unused lore tagline from renderer files
- document geometry sources for Vesica, Fibonacci, Tree-of-Life, and helix lattice

## Testing
- `node -e "import('./js/helix-renderer.mjs').then(()=>console.log('module ok'))"`
- `node -e "const fs=require('fs');console.log('layers',JSON.parse(fs.readFileSync('data/palette.json','utf8')).layers.length);"`


------
https://chatgpt.com/codex/tasks/task_e_68c4fc8196b4832887f1bebdb2a03645